### PR TITLE
Add JavaScript Licenses

### DIFF
--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,6 +1,7 @@
 <!-- js from https://codepen.io/MrGrigri/pen/XQmWBv -->
 
 <script>
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat
     const themePreference = () => {
         const hasLocalStorage = localStorage.getItem('theme');
         let supports = false;
@@ -66,4 +67,5 @@
             }
         }, false);
     }, false);
+// @license-end
 </script>


### PR DESCRIPTION
The GNU Project keeps a format for licensing JavaScript within the web browser. 

This PR should make this repository compliant: https://www.gnu.org/software/librejs/